### PR TITLE
修复卡车丢失Bugs(配方丢失Bugs)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ modGroup = gregtech
 
 # Version of your mod.
 # This field can be left empty if you want your mod's version to be determined by the latest git tag instead.
-modVersion = 2.9.0-188
+modVersion = 2.9.0-190
 
 # Whether to use the old jar naming structure (modid-mcversion-version) instead of the new version (modid-version)
 includeMCVersionJar = true

--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -71,7 +71,7 @@ public abstract class AbstractRecipeLogic extends MTETrait
     protected LinkedList<Recipe> latestRecipes = new LinkedList<>();
     protected int parallelRecipesPerformed;
     protected boolean canRecipeProgress = true;
-    protected int progressTime;
+    public int progressTime;
     protected int maxProgressTime;
     protected long recipeEUt;
     @NotNull

--- a/src/main/java/gregtech/api/metatileentity/multiblock/AdvanceMultiMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/AdvanceMultiMapMultiblockController.java
@@ -192,7 +192,7 @@ public abstract class AdvanceMultiMapMultiblockController extends AdvanceRecipeM
 
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound data) {
-        super.writeToNBT(data);
+         super.writeToNBT(data);
         data.setInteger("RecipeMapIndex", recipeMapIndex);
         return data;
     }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/AdvanceRecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/AdvanceRecipeMapMultiblockController.java
@@ -1,5 +1,6 @@
 package gregtech.api.metatileentity.multiblock;
 
+import gregtech.GregTechMod;
 import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechDataCodes;
 import gregtech.api.capability.IDistinctBusController;
@@ -44,6 +45,7 @@ import gtqt.api.util.GTQTUtility;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -53,7 +55,6 @@ public abstract class AdvanceRecipeMapMultiblockController extends RecipeMapMult
                    IDistinctBusController {
 
     public final RecipeMap<?> recipeMap;
-
     protected ArrayList<MultiblockRecipeLogic> recipeMapWorkable = new ArrayList<>();
 
     protected IItemHandlerModifiable inputInventory;
@@ -85,6 +86,7 @@ public abstract class AdvanceRecipeMapMultiblockController extends RecipeMapMult
     }
 
     public IEnergyContainer getEnergyContainer() {
+
         return energyContainer;
     }
 
@@ -122,13 +124,17 @@ public abstract class AdvanceRecipeMapMultiblockController extends RecipeMapMult
 
         thread = this.getAbilities(MultiblockAbility.THREAD_HATCH).isEmpty() ? 1 :
                 this.getAbilities(MultiblockAbility.THREAD_HATCH).get(0).getCurrentThread();
-
+        if(!recipeMapWorkable.isEmpty()) return;
         recipeMapWorkable = new ArrayList<>();
         for (int i = 0; i < thread; i++)
             recipeMapWorkable.add(new MultiblockRecipeLogic(this));
+
     }
 
     public void refreshThread(int thread) {
+        if(recipeMapWorkable.size() == 2) {
+
+        }
         if (!checkWorkingEnable()) {
             forceRefreshThread(thread);
         }
@@ -366,6 +372,7 @@ public abstract class AdvanceRecipeMapMultiblockController extends RecipeMapMult
 
     @Override
     public void receiveCustomData(int dataId, @NotNull PacketBuffer buf) {
+
         super.receiveCustomData(dataId, buf);
         if (dataId == GregtechDataCodes.UPDATE_THREAD_STATE) {
             this.thread = buf.readInt();
@@ -374,9 +381,14 @@ public abstract class AdvanceRecipeMapMultiblockController extends RecipeMapMult
 
     @Override
     public void writeInitialSyncData(PacketBuffer buf) {
+        //在此之前recipeMapWorkable已经被修改
         super.writeInitialSyncData(buf);
+
         buf.writeBoolean(isDistinct);
         buf.writeInt(thread);
+        for (int i = 0; i < recipeMapWorkable.size(); i++) {
+            buf.writeCompoundTag(recipeMapWorkable.get(i).serializeNBT());
+        }
         for (MultiblockRecipeLogic logic : recipeMapWorkable) {
             logic.writeInitialSyncData(buf);
         }
@@ -384,13 +396,28 @@ public abstract class AdvanceRecipeMapMultiblockController extends RecipeMapMult
 
     @Override
     public void receiveInitialSyncData(PacketBuffer buf) {
+        ArrayList<MultiblockRecipeLogic> recipeMapWorkable_Temp = new ArrayList<>();
         super.receiveInitialSyncData(buf);
         isDistinct = buf.readBoolean();
         thread = buf.readInt();
         forceRefreshThread(thread); // 使用实际读取的数量
+        for(int i = 0;i < thread;i++){
+            recipeMapWorkable_Temp.add(new MultiblockRecipeLogic(this));
+        }
+        for (int i = 0; i < thread; i++) {
+            try {
+                NBTTagCompound nbt = buf.readCompoundTag();
+                assert nbt != null;
+                recipeMapWorkable_Temp.get(i).deserializeNBT(nbt);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            //recipeMapWorkable.set(i,buf.readCompoundTag());
+        }
         for (MultiblockRecipeLogic logic : recipeMapWorkable) {
             logic.receiveInitialSyncData(buf);
         }
+        recipeMapWorkable = recipeMapWorkable_Temp;
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
@@ -1,5 +1,6 @@
 package gregtech.api.metatileentity.multiblock;
 
+import gregtech.GregTechMod;
 import gregtech.api.GregTechAPI;
 import gregtech.api.block.VariantActiveBlock;
 import gregtech.api.capability.GregtechCapabilities;


### PR DESCRIPTION
版本号跟进到1.9.0
修复重启后配方丢失的Bug
Bug原因FromStructure(GTCEU和GCYM)函数在启动的时候进行成型检测，清空的RecipeMapWorkable